### PR TITLE
fix: minor fixes ensuring lobby endpoints use validateJwt correctly

### DIFF
--- a/www/lobby/id.ts
+++ b/www/lobby/id.ts
@@ -1,7 +1,7 @@
 import { Router, Request, Response } from 'express';
 import { User } from '../../lib';
 import { Lobby } from '../../lib/lobby';
-import { validateUserJwt, validateLobbyJwt } from '../../utils/jwt';
+import { validateLobbyJwt } from '../../utils/jwt';
 
 interface VerifiedObjects {
   user: User;
@@ -15,7 +15,7 @@ export const lobby_id_router = Router();
  *
  * Body Params: id, lobbyToken, refreshToken
  */
-lobby_id_router.post('/:id', validateUserJwt, validateLobbyJwt, async (req: Request, res: Response) => {
+lobby_id_router.post('/:id', validateLobbyJwt, async (req: Request, res: Response) => {
   const userId: string = req.body.userId;
   const lobbyId: string = req.params.id;
   const decodedLobbyId: string | undefined = req.body.lobbyId;
@@ -65,7 +65,7 @@ lobby_id_router.get('/:id', async (req: Request, res: Response) => {
 lobby_id_router.patch('/:id', async (req: Request, res: Response) => {
   const lobbyId = req.params.id;
   const userId = req.body.userId;
-  const name: string = req.body.lobbyName;
+  const name: string = req.body.name;
   const verified = await verifyIds(userId, lobbyId);
   if (!verified) return res.status(404).json('User or Lobby not found in database').end();
   const { lobby } = verified;

--- a/www/lobby/index.ts
+++ b/www/lobby/index.ts
@@ -17,7 +17,7 @@ lobby_router.use('/', lobby_id_router);
 lobby_router.post('/', async (req: Request, res: Response) => {
   const lobbyName = req.body.lobbyName;
   const theme = req.body.theme;
-  const userId = req.body.id;
+  const userId = req.body.userId;
 
   const manager = await User.fromId(userId);
   if (!manager) return res.status(404).json('user not found in database').end();


### PR DESCRIPTION
Small changes:
- make sure `req.body.id` is replaced with `req.body.userId`
- Design doc for PATCH lobby/:id endpoint says to put the new lobby name in `req.body.name` whereas the code was using `req.body.lobbyName`

The lobby GET, lobby/:id POST, lobby/:id PATCH, lobby/:id GET, and lobby/:id/user/:deleteId DELETE endpoints were all tested

closes #34 