### PR TITLE
feat: Implement filler for lobby song generation

### DIFF
--- a/lib/lobby.ts
+++ b/lib/lobby.ts
@@ -125,6 +125,17 @@ export class Lobby extends DbItem implements ILobby {
     this.#name = props.name;
     this.#participants = props.participants ?? [props.managerId];
     this.#songIds = props.songIds ?? [];
+    this.setSongs();
+  }
+
+  /**
+   * Sets the Songs for the playlist
+   */
+   public async setSongs(writeToDatabase = true): Promise<void> {
+    const manager = await User.fromId(this.managerId);
+    // TODO: replace this with Pan's algorithm
+    this.#songIds = manager?.topSongs ?? [];
+    writeToDatabase && void this.writeToDatabase();
   }
 
   /**
@@ -173,7 +184,7 @@ export class Lobby extends DbItem implements ILobby {
    */
   public getClientResponse(): ClientResponse {
     const {collectionName: _c, ...response} = this;
-    return {...response, name: this.name, participants: this.participants};
+    return {...response, name: this.name, participants: this.participants, songIds: this.songIds};
   }
 
   /**

--- a/lib/lobby.ts
+++ b/lib/lobby.ts
@@ -125,13 +125,13 @@ export class Lobby extends DbItem implements ILobby {
     this.#name = props.name;
     this.#participants = props.participants ?? [props.managerId];
     this.#songIds = props.songIds ?? [];
-    this.setSongs();
+    void this.setSongs();
   }
 
   /**
    * Sets the Songs for the playlist
    */
-   public async setSongs(writeToDatabase = true): Promise<void> {
+  public async setSongs(writeToDatabase = true): Promise<void> {
     const manager = await User.fromId(this.managerId);
     // TODO: replace this with Pan's algorithm
     this.#songIds = manager?.topSongs ?? [];

--- a/lib/lobby.ts
+++ b/lib/lobby.ts
@@ -134,7 +134,7 @@ export class Lobby extends DbItem implements ILobby {
   public async setSongs(writeToDatabase = true): Promise<void> {
     const manager = await User.fromId(this.managerId);
     // TODO: replace this with Pan's algorithm
-    this.#songIds = manager?.topSongs ?? [];
+    this.#songIds = manager?.topSongs.slice(0,50) ?? [];
     writeToDatabase && void this.writeToDatabase();
   }
 

--- a/www/lobby/id.ts
+++ b/www/lobby/id.ts
@@ -128,6 +128,7 @@ lobby_id_router.delete('/:id/user/:deleteId', async (req: Request, res: Response
 });
 
 const verifyIds = async (userId: string, lobbyId: string): Promise<VerifiedObjects | null> => {
+  if (!userId || !lobbyId) return null;
   const user = await User.fromId(userId);
   if (!user) return null;
   const lobby = await Lobby.fromId(lobbyId);


### PR DESCRIPTION
Returns the top songs of the manager of a lobby as the songs for a lobby's playlist

I also fixed a bug in the verifyIds function
- when the userId is null, the User.fromId(userId) treats it as 0 and retrieves the CL account user