### PR TITLE
feat: include lobbyToken in GET lobby/:id response

### DIFF
--- a/www/lobby/id.ts
+++ b/www/lobby/id.ts
@@ -3,7 +3,7 @@ import { User } from '../../lib';
 import { Lobby } from '../../lib/lobby';
 import { deleteSpotifyPlaylist } from '../../lib/spotify/delete-playlist';
 import { updateSpotifyPlaylist } from '../../lib/spotify/update-playlist';
-import { validateLobbyJwt } from '../../utils/jwt';
+import { validateLobbyJwt, genJwt, EXPIRATION } from '../../utils/jwt';
 
 interface VerifiedObjects {
   user: User;
@@ -56,7 +56,8 @@ lobby_id_router.get('/:id', async (req: Request, res: Response) => {
   const { lobby } = verified;
   if (!lobby.participants.includes(userId)) return res.status(406).json('User is not part of the lobby').end();
 
-  res.status(200).json(lobby.getClientResponse());
+  const lobbyToken = genJwt(lobbyId, EXPIRATION.SEVEN_DAYS);
+  res.status(200).json({...lobby.getClientResponse(), lobbyToken: lobbyToken});
 });
 
 /**

--- a/www/lobby/id.ts
+++ b/www/lobby/id.ts
@@ -56,8 +56,14 @@ lobby_id_router.get('/:id', async (req: Request, res: Response) => {
   const { lobby } = verified;
   if (!lobby.participants.includes(userId)) return res.status(406).json('User is not part of the lobby').end();
 
-  const lobbyToken = genJwt(lobbyId, EXPIRATION.SEVEN_DAYS);
-  res.status(200).json({...lobby.getClientResponse(), lobbyToken: lobbyToken});
+  let resObj: Object = lobby.getClientResponse();
+
+  if (userId == lobby.managerId) {
+    const lobbyToken = genJwt(lobbyId, EXPIRATION.SEVEN_DAYS);
+    resObj = {...resObj, lobbyToken: lobbyToken};
+  }
+  
+  res.status(200).json(resObj);
 });
 
 /**

--- a/www/lobby/id.ts
+++ b/www/lobby/id.ts
@@ -56,14 +56,9 @@ lobby_id_router.get('/:id', async (req: Request, res: Response) => {
   const { lobby } = verified;
   if (!lobby.participants.includes(userId)) return res.status(406).json('User is not part of the lobby').end();
 
-  let resObj: Record<string, unknown> = lobby.getClientResponse();
-
-  if (userId == lobby.managerId) {
-    const lobbyToken = genJwt(lobbyId, EXPIRATION.SEVEN_DAYS);
-    resObj = {...resObj, lobbyToken: lobbyToken};
-  }
-
-  res.status(200).json(resObj);
+  res.status(200).json(userId === lobby.managerId
+    ? lobby.getClientResponse()
+    : {...lobby.getClientResponse, lobbyToken: genJwt(lobbyId, EXPIRATION.ONE_HOUR}
 });
 
 /**

--- a/www/lobby/id.ts
+++ b/www/lobby/id.ts
@@ -57,8 +57,8 @@ lobby_id_router.get('/:id', async (req: Request, res: Response) => {
   if (!lobby.participants.includes(userId)) return res.status(406).json('User is not part of the lobby').end();
 
   res.status(200).json(userId === lobby.managerId
-    ? lobby.getClientResponse()
-    : {...lobby.getClientResponse, lobbyToken: genJwt(lobbyId, EXPIRATION.ONE_HOUR}
+    ? {...lobby.getClientResponse(), lobbyToken: genJwt(lobbyId, EXPIRATION.ONE_HOUR)}
+    : lobby.getClientResponse());
 });
 
 /**

--- a/www/lobby/id.ts
+++ b/www/lobby/id.ts
@@ -56,13 +56,13 @@ lobby_id_router.get('/:id', async (req: Request, res: Response) => {
   const { lobby } = verified;
   if (!lobby.participants.includes(userId)) return res.status(406).json('User is not part of the lobby').end();
 
-  let resObj: Object = lobby.getClientResponse();
+  let resObj: Record<string, unknown> = lobby.getClientResponse();
 
   if (userId == lobby.managerId) {
     const lobbyToken = genJwt(lobbyId, EXPIRATION.SEVEN_DAYS);
     resObj = {...resObj, lobbyToken: lobbyToken};
   }
-  
+
   res.status(200).json(resObj);
 });
 


### PR DESCRIPTION
Small change: The lobbyToken of the lobby is included in the response to lobby/:id GET