### PR TITLE
feat: Make users follow/unfollow playlists when they join/leave lobby

### DIFF
--- a/lib/lobby.ts
+++ b/lib/lobby.ts
@@ -5,6 +5,8 @@ import { compareSongScores, computeScore, Song2Score } from './playlist-generati
 import { THEME } from './playlist-generation/themes';
 import { COLLECTION } from './private/enums';
 import { createSpotifyPlaylist } from './spotify/create-playlist';
+import { followPlaylist } from './spotify/follow-playlist';
+import { unfollowPlaylist } from './spotify/unfollow-playlist';
 
 type DatabaseEntry = Omit<ILobby, 'collectionName'>;
 type ClientResponse = {
@@ -159,7 +161,8 @@ export class Lobby extends DbItem implements ILobby {
     this.#participants.push(user.id);
     void user.addLobby(this.id);
     writeToDb && void this.writeToDatabase();
-    return true;
+    const addedToPlaylist = await followPlaylist(user, this.id);
+    return addedToPlaylist;
   }
 
   /**
@@ -171,7 +174,8 @@ export class Lobby extends DbItem implements ILobby {
     this.#participants = this.#participants.filter(uid => uid !== removeUserId);
     void user.removeLobby(this.id);
     writeToDb && void this.writeToDatabase();
-    return true;
+    const removedFromPlaylist = await unfollowPlaylist(user, this.id);
+    return removedFromPlaylist;
   }
 
   /**

--- a/lib/spotify/follow-playlist.ts
+++ b/lib/spotify/follow-playlist.ts
@@ -11,24 +11,20 @@
  * returns true if the user successfully followed the playlist
  */
 
- import fetch from 'node-fetch';
- import { User } from '..';
- 
- export const followPlaylist = async (user: User, playlistId: string): Promise<boolean> => {
-   
- 
-   const accessToken = await user.getAccessToken();
-  
-   const res = await fetch(`https://api.spotify.com/v1/playlists/${playlistId}/followers`, {
-     method: 'PUT',
-     headers: {
-       'Content-Type': 'application/json',
-       'Authorization': 'Bearer ' + accessToken,
-       'Host': 'api.spotify.com',
-     },
-     body: JSON.stringify({'public': true}),
-   });
-   console.log(await res.json());
- 
-   return res.ok;
- };
+import fetch from 'node-fetch';
+import { User } from '..';
+
+export const followPlaylist = async (user: User, playlistId: string): Promise<boolean> => {
+  const accessToken = await user.getAccessToken();
+  const res = await fetch(`https://api.spotify.com/v1/playlists/${playlistId}/followers`, {
+    method: 'PUT',
+    headers: {
+      'Content-Type': 'application/json',
+      'Authorization': 'Bearer ' + accessToken,
+      'Host': 'api.spotify.com',
+    },
+    body: JSON.stringify({ 'public': false }),
+  });
+
+  return res.ok;
+};

--- a/lib/spotify/follow-playlist.ts
+++ b/lib/spotify/follow-playlist.ts
@@ -1,0 +1,34 @@
+/**
+ * Spotify API Follow Playlist Endpoint
+ * https://developer.spotify.com/documentation/web-api/reference/#/operations/follow-playlist
+ * PUT /playlists/{playlist_id}/followers
+ * Body:
+ * public: boolean
+ * 
+ * followPlaylist
+ * params: accessToken, playlist_id
+ * 
+ * returns true if the user successfully followed the playlist
+ */
+
+ import fetch from 'node-fetch';
+ import { User } from '..';
+ 
+ export const followPlaylist = async (user: User, playlistId: string): Promise<boolean> => {
+   
+ 
+   const accessToken = await user.getAccessToken();
+  
+   const res = await fetch(`https://api.spotify.com/v1/playlists/${playlistId}/followers`, {
+     method: 'PUT',
+     headers: {
+       'Content-Type': 'application/json',
+       'Authorization': 'Bearer ' + accessToken,
+       'Host': 'api.spotify.com',
+     },
+     body: JSON.stringify({'public': true}),
+   });
+   console.log(await res.json());
+ 
+   return res.ok;
+ };

--- a/lib/spotify/follow-playlist.ts
+++ b/lib/spotify/follow-playlist.ts
@@ -4,10 +4,10 @@
  * PUT /playlists/{playlist_id}/followers
  * Body:
  * public: boolean
- * 
+ *
  * followPlaylist
  * params: accessToken, playlist_id
- * 
+ *
  * returns true if the user successfully followed the playlist
  */
 
@@ -23,7 +23,7 @@ export const followPlaylist = async (user: User, playlistId: string): Promise<bo
       'Authorization': 'Bearer ' + accessToken,
       'Host': 'api.spotify.com',
     },
-    body: JSON.stringify({ 'public': false }),
+    body: JSON.stringify({ public: false }),
   });
 
   return res.ok;

--- a/lib/spotify/unfollow-playlist.ts
+++ b/lib/spotify/unfollow-playlist.ts
@@ -1,0 +1,31 @@
+/**
+ * Spotify API Unfollow Playlist Endpoint
+ * https://developer.spotify.com/documentation/web-api/reference/#/operations/unfollow-playlist
+ * DELETE /playlists/{playlist_id}/followers
+ * 
+ * unfollowPlaylist
+ * params: accessToken, playlist_id
+ * 
+ * returns true if the user successfully unfollowed the playlist
+ */
+
+ import fetch from 'node-fetch';
+ import { User } from '..';
+ 
+ export const unfollowPlaylist = async (user: User, playlistId: string): Promise<boolean> => {
+   
+ 
+   const accessToken = await user.getAccessToken();
+  
+   const res = await fetch(`https://api.spotify.com/v1/playlists/${playlistId}/followers`, {
+     method: 'DELETE',
+     headers: {
+       'Content-Type': 'application/json',
+       'Authorization': 'Bearer ' + accessToken,
+       'Host': 'api.spotify.com',
+     },
+   });
+   console.log(await res.json());
+ 
+   return res.ok;
+ };

--- a/lib/spotify/unfollow-playlist.ts
+++ b/lib/spotify/unfollow-playlist.ts
@@ -2,10 +2,10 @@
  * Spotify API Unfollow Playlist Endpoint
  * https://developer.spotify.com/documentation/web-api/reference/#/operations/unfollow-playlist
  * DELETE /playlists/{playlist_id}/followers
- * 
+ *
  * unfollowPlaylist
  * params: accessToken, playlist_id
- * 
+ *
  * returns true if the user successfully unfollowed the playlist
  */
 

--- a/lib/spotify/unfollow-playlist.ts
+++ b/lib/spotify/unfollow-playlist.ts
@@ -9,23 +9,20 @@
  * returns true if the user successfully unfollowed the playlist
  */
 
- import fetch from 'node-fetch';
- import { User } from '..';
- 
- export const unfollowPlaylist = async (user: User, playlistId: string): Promise<boolean> => {
-   
- 
-   const accessToken = await user.getAccessToken();
-  
-   const res = await fetch(`https://api.spotify.com/v1/playlists/${playlistId}/followers`, {
-     method: 'DELETE',
-     headers: {
-       'Content-Type': 'application/json',
-       'Authorization': 'Bearer ' + accessToken,
-       'Host': 'api.spotify.com',
-     },
-   });
-   console.log(await res.json());
- 
-   return res.ok;
- };
+import fetch from 'node-fetch';
+import { User } from '..';
+
+export const unfollowPlaylist = async (user: User, playlistId: string): Promise<boolean> => {
+  const accessToken = await user.getAccessToken();
+
+  const res = await fetch(`https://api.spotify.com/v1/playlists/${playlistId}/followers`, {
+    method: 'DELETE',
+    headers: {
+      'Content-Type': 'application/json',
+      'Authorization': 'Bearer ' + accessToken,
+      'Host': 'api.spotify.com',
+    },
+  });
+
+  return res.ok;
+};

--- a/lib/user.ts
+++ b/lib/user.ts
@@ -2,6 +2,8 @@ import { getAccessToken, getClient, SpotifySubscriptionType } from '.';
 import { DbItem, IDbItem } from './db-item';
 import { COLLECTION } from './private/enums';
 import { getTopSongs } from './spotify/top-songs';
+import { followPlaylist } from './spotify/follow-playlist';
+import { unfollowPlaylist } from './spotify/unfollow-playlist';
 
 type DatabaseEntry = Omit<IUser, 'collectionName'>;
 type ClientResponse = Omit<DatabaseEntry, 'uri'>;
@@ -155,17 +157,22 @@ export class User extends DbItem implements IUser {
   /**
    * Add a lobby to the user's lobby list
    */
-  public async addLobby(lobbyId: string, writeToDatabase = true): Promise<void> {
+  public async addLobby(lobbyId: string, writeToDatabase = true): Promise<boolean> {
     this.#lobbies.push(lobbyId);
     if (writeToDatabase) void this.writeToDatabase();
+    // console.log("attempting to have : "+this.id +" follow playlist "+)
+    const addedToPlaylist = await followPlaylist(this, lobbyId);
+    return addedToPlaylist;
   }
 
   /**
    * Remove a lobby from the user's lobby list
    */
-  public async removeLobby(lobbyId: string, writeToDatabase = true): Promise<void> {
+  public async removeLobby(lobbyId: string, writeToDatabase = true): Promise<boolean> {
     this.#lobbies = this.#lobbies.filter(id => id !== lobbyId);
     if (writeToDatabase) void this.writeToDatabase();
+    const removedFromPlaylist = await unfollowPlaylist(this, lobbyId);
+    return removedFromPlaylist;
   }
 
   /**


### PR DESCRIPTION
- Add followPlaylist function which uses the Spotify [PUT endpoint](https://developer.spotify.com/documentation/web-api/reference/#/operations/follow-playlist) to make a user follow a playlist
- Add unfollowPlaylist function which uses the Spotify [DELETE endpoint](https://developer.spotify.com/documentation/web-api/reference/#/operations/unfollow-playlist) to make a user follow a playlist
- Have the user addLobby and removeLobby functions call the followPlaylist and unfollowPlaylist function
- When a user creates a lobby, their spotify account will also follow the spotify playlist
- When a user joins or leaves a lobby, their spotify account will also follow/unfollow the spotify playlist, respectively
- When a manager of a lobby deletes a lobby, the manager and all the users in the lobby will also unfollow the spotify playlist