### PR TITLE
feat: add GET lobby/themes endpoint

### DIFF
--- a/www/lobby/index.ts
+++ b/www/lobby/index.ts
@@ -5,9 +5,11 @@ import { User } from '../../lib/user';
 import { logger } from '../../utils';
 import { validateUserJwt } from '../../utils/jwt';
 import { lobby_id_router } from './id';
+import { lobby_themes_router } from './themes';
 
 export const lobby_router = Router();
 
+lobby_router.use('/', lobby_themes_router);
 lobby_router.use('/', validateUserJwt);
 lobby_router.use('/', lobby_id_router);
 

--- a/www/lobby/themes.ts
+++ b/www/lobby/themes.ts
@@ -1,0 +1,7 @@
+import { Router, Request, Response } from 'express';
+import { theme2Conditions } from '../../lib/playlist-generation/themes';
+export const lobby_themes_router = Router();
+
+lobby_themes_router.get('/themes', async (req: Request, res: Response) => {
+  res.status(200).json(Object.keys(theme2Conditions));
+});


### PR DESCRIPTION
Added a new endpoint `/lobby/themes` that returns an array of the names of the possible themes
I made this endpoint have no authorization because I feel like it is something that is ok to be exposed to anyone that wants to see it